### PR TITLE
Narrative Director Tweaks

### DIFF
--- a/Assets/InkFungus/Resources/Prefabs/Ink-Fungus Gateway.prefab
+++ b/Assets/InkFungus/Resources/Prefabs/Ink-Fungus Gateway.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   saveMessage: save
   loadMessage: load
   newKnotStitchMessage: at
-  dialogRegex: ^(?<character>[\w\-]*)(\?(?<portrait>[\w\-]+))? "(?<text>(("[^"]*")|([^"]+))+?)"?[
+  dialogRegex: ^(?<character>[\w\- ]*)(\?(?<portrait>[\w\-]+))? "(?<text>(("[^"]*")|([^"]+))+?)"?[
     ]*$
   gatewayFlowchart: {fileID: 4558443714015105650}
   defaultChoiceTime: 5

--- a/Assets/InkFungus/Scripts/NarrativeDirector.cs
+++ b/Assets/InkFungus/Scripts/NarrativeDirector.cs
@@ -314,7 +314,6 @@ namespace InkFungus
         public void JumpTo(string pathString)
         {            
             story.ChoosePathString(pathString);
-            BroadcastToFungus(textResumeMessage);
             Resume(true);
         }
 

--- a/Assets/InkFungus/Scripts/NarrativeDirector.cs
+++ b/Assets/InkFungus/Scripts/NarrativeDirector.cs
@@ -66,6 +66,9 @@ namespace InkFungus
         private const string ListItemSeparator = "__";
         private readonly string[] ListItemSeparators = { ListItemSeparator };
 
+        // Used to immediately stop dialogue
+        private bool immediateStop = false;
+
         private class Flag
         {
             public bool ordinaryValue;
@@ -332,6 +335,11 @@ namespace InkFungus
             BroadcastToFungus(textPauseMessage);
         }
 
+        public void CutDialogue()
+        {
+            immediateStop = true;
+        }
+
         public void Resume(bool force = false)
         {
             if (pause || force)
@@ -368,6 +376,15 @@ namespace InkFungus
                 string line = story.currentText;
                 Debug.Log("»" + line);
                 ProcessTags(story.currentTags);
+
+                if (immediateStop)
+                {
+                    immediateStop = false;
+                    pauseTime = float.PositiveInfinity;
+                    Idle();
+                    return;
+                }
+
                 bool verbatim = flags["verbatim"].Get();
                 Match dialogLine = null;
                 Sprite portrait = null;

--- a/Assets/InkFungus/Scripts/NarrativeDirector.cs
+++ b/Assets/InkFungus/Scripts/NarrativeDirector.cs
@@ -37,7 +37,7 @@ namespace InkFungus
 
         [Header("Advanced Settings")]
         public string dialogRegex =
-        @"^(?<character>[\w\- ]*)(\?(?<portrait>[\w\-]+))? ""(?<text>((""[^""]*"")|(.))+?)""?[ ]*$";
+        @"^(?<character>[\w\- ]*)(\?(?<portrait>[\w\- ]+))? ""(?<text>((""[^""]*"")|(.))+?)""?[ ]*$";
         public Flowchart gatewayFlowchart;
         public float defaultChoiceTime = 5f;
 


### PR DESCRIPTION
This performs three main changes, outlined in the commits.

1. When using `JumpTo`, `BroadcastToFungus(textResumeMessage)` is only called once

2. There are times when dialogue should be stopped when the tag is read of the current dialogue line (ex: # cutdialogue). This change stops the dialogue before the line is displayed.

3. Adds white space matching for dialogue characters with multiple names (Firstname Lastname)